### PR TITLE
REF: Update to 0.2.1, which includes migrating to the AWS Java SDK to…

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject tumalo "0.2.0"
+(defproject tumalo "0.2.1"
   :description "Clojure Elasticsearch Indexing Tools"
   :license {:name "MIT"
             :url "https://opensource.org/licenses/MIT"}
@@ -6,8 +6,8 @@
                  [org.clojure/tools.logging "0.3.1"]
                  [org.clojure/core.async "0.2.374"]
                  [ch.qos.logback/logback-classic "1.1.3"]
-                 [amazonica "0.3.59"]
-                 [clojurewerkz/elastisch "2.2.1"]
+                 [clojurewerkz/elastisch "2.2.1" :exclusions [com.fasterxml.jackson.core/jackson-core]]
+                 [com.amazonaws/aws-java-sdk-s3 "1.11.35"]
                  [prismatic/schema "1.1.1"]
                  [clj-http "2.2.0"]
                  [clj-time "0.11.0"]]

--- a/project.clj
+++ b/project.clj
@@ -14,5 +14,4 @@
   :resource-paths ["resources"]
   :profiles {:dev {:resource-paths ["resources/test"]}
              :uberjar {:aot :all}}
-  :global-vars {*warn-on-reflection* true}
-  :javac-options ["-target" "1.8" "-source" "1.8"])
+  :global-vars {*warn-on-reflection* true})


### PR DESCRIPTION
Amazonica had some bugs, so move to aws sdk. Unfortunately there are some jackson dep collisions between elastisch and the aws sdk, which the exclusion fixes for now. 
